### PR TITLE
6주차 이현진

### DIFF
--- a/src/week_6/백준_1_123더하기_이현진.java
+++ b/src/week_6/백준_1_123더하기_이현진.java
@@ -1,0 +1,23 @@
+package week_6;
+
+import java.util.*;
+
+public class 백준_1_123더하기_이현진 {
+    public static void main(String[] args) {
+        int[] sum = new int[12];
+        sum[0] = 0;
+        sum[1] = 1;
+        sum[2] = 2;
+        sum[3] = 4;
+
+        Scanner sc = new Scanner(System.in);
+        int n = sc.nextInt();
+        for(int i = 0; i < n; i++){
+            int test = sc.nextInt();
+            for(int j = 4; j <= test; j++){
+                sum[j] = sum[j-1] + sum[j-2] + sum[j-3];
+            }
+            System.out.println(sum[test]);
+        }
+    }
+}

--- a/src/week_6/프로그래머스_1_정수삼각형_이현진.java
+++ b/src/week_6/프로그래머스_1_정수삼각형_이현진.java
@@ -1,0 +1,27 @@
+package week_6;
+
+public class 프로그래머스_1_정수삼각형_이현진 {
+    public static void main(String[] args) {
+        int[][] nums = {{7}, {3, 8}, {8, 1, 0}, {2, 7, 4, 4}, {4, 5, 2, 6, 5}};
+        System.out.println(solution(nums));
+    }
+
+    public static int solution(int[][] triangle) {
+        int n = triangle.length;
+        int[][] dp = new int[n][n];
+
+        // 가장 마지막 행을 복사
+        for (int i = 0; i < triangle[n - 1].length; i++) {
+            dp[n - 1][i] = triangle[n - 1][i];
+        }
+
+        // 마지막부터 더해서 위로 올라오기
+        for (int i = n - 2; i >= 0; i--) {
+            for (int j = 0; j < triangle[i].length; j++) {
+                dp[i][j] = triangle[i][j] + Math.max(dp[i + 1][j], dp[i + 1][j + 1]);
+            }
+        }
+
+        return dp[0][0];
+    }
+}

--- a/src/week_6/프로그래머스_2_등굣길.java
+++ b/src/week_6/프로그래머스_2_등굣길.java
@@ -1,0 +1,33 @@
+package week_6;
+
+public class 프로그래머스_2_등굣길 {
+    public int solution(int m, int n, int[][] puddles) {
+        int[][] dp = new int[m][n];
+
+        // 물 웅덩이 먼저 표시
+        for (int[] puddle : puddles) {
+            int mm = puddle[0], nn = puddle[1];
+            dp[mm - 1][nn - 1] = -1;
+        }
+
+        // 시작점
+        dp[0][0] = 1;
+
+        // 경로 저장
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                // 물 웅덩이면 0으로 처리하고 건너뛰기
+                if (dp[i][j] == -1) {
+                    dp[i][j] = 0;
+                    continue;
+                }
+
+                if (i > 0) dp[i][j] += dp[i - 1][j];
+                if (j > 0) dp[i][j] += dp[i][j - 1];
+                dp[i][j] %= 1000000007;
+            }
+        }
+
+        return dp[m - 1][n - 1];
+    }
+}

--- a/src/week_6/프로그래머스_3_파괴되지않은건물.java
+++ b/src/week_6/프로그래머스_3_파괴되지않은건물.java
@@ -1,0 +1,57 @@
+package week_6;
+
+public class 프로그래머스_3_파괴되지않은건물 {
+    public static void main(String[] args) {
+        int[][] board = {{5,5,5,5,5}, {5,5,5,5,5}, {5,5,5,5,5}, {5,5,5,5,5}};
+        int[][] skill = {{1,0,0,3,4,4},{1,2,0,2,3,2},{2,1,0,3,1,2},{1,0,1,3,3,1}};
+        System.out.println(solution(board, skill));
+    }
+
+    private static int[][] sum;
+
+    public static int solution(int[][] board, int[][] skill) {
+        // skill의 각 행은 [type, r1, c1, r2, c2, degree]
+        // type이 1일 경우는 적의 공격
+        // type이 2일 경우는 아군의 회복 스킬
+        int n = board.length, m = board[0].length;
+        sum = new int[n+1][m+1];
+
+        for (int[] s : skill) {
+            int y1 = s[1], x1 = s[2];
+            int y2 = s[3], x2 = s[4];
+            int degree = s[5] * (s[0] == 1 ? -1 : 1);
+
+            sum[y1][x1] += degree;
+            sum[y1][x2 + 1] += (degree * -1);
+            sum[y2 + 1][x1] += (degree * -1);
+            sum[y2 + 1][x2 + 1] += degree;
+        }
+
+        operate(n, m);
+
+        // 살아남은 건물 확인
+        int answer = 0;
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                if (board[i][j] + sum[i][j] > 0) answer++;
+            }
+        }
+        return answer;
+    }
+
+    // 누적합 계산
+    private static void operate(int n, int m) {
+        // 상하
+        for (int y = 1; y < n; y++) {
+            for (int x = 0; x < m; x++) {
+                sum[y][x] += sum[y - 1][x];
+            }
+        }
+        // 좌우
+        for (int x = 1; x < m; x++) {
+            for (int y = 0; y < n; y++) {
+                sum[y][x] += sum[y][x - 1];
+            }
+        }
+    }
+}


### PR DESCRIPTION
## ✨ Week 6

### 1️⃣ 정수 삼각형
#### 📌 문제 설명
```
삼각형의 꼭대기에서 시작해 아래로 내려오며 숫자를 하나씩 선택할 때,  
거쳐간 숫자의 합이 가장 큰 경로의 합을 구하라.
- 아래 행의 인접한 두 개 숫자 중 하나만 선택 가능
```

#### 🧠 풀이 방법
```
1. DP 2차원 배열 선언: dp[i][j] → (i, j)까지의 최대 합 저장
2. 삼각형의 맨 아래 행을 dp의 마지막 행으로 초기화
3. 아래에서 위로 올라가며 각 위치에서 선택할 수 있는 두 경로 중 더 큰 값을 더함
4. 최종적으로 dp[0][0]이 최대 경로의 합
```

#### 💡 새로 알게 된 개념
키워드 | 설명
-- | --
Bottom-up DP | 반복문으로 아래에서 위로 누적 합 계산
2차원 DP 배열 | 위치별 최대 누적값 저장용
Math.max(a, b) | 두 경로 중 더 큰 값 선택
배열 복사 | for문을 이용해 마지막 행 값을 그대로 dp에 복사

#### 🤔 막혔던 점
처음에는 DFS 방식으로 재귀 호출을 시도했으나, 중복 연산과 깊은 재귀로 인해 시간 초과 발생
→ 반복문을 이용한 Bottom-up 방식으로 전환하여 해결

---
### 2️⃣ 등굣길
#### 📌 문제 설명
```
m x n 격자에서 (1,1) → (m,n)까지  
오른쪽 또는 아래로만 이동 가능한 최단 경로의 수를 구하라.

단, 물에 잠긴 지역(puddle)은 지나갈 수 없으며  
경로의 수는 1,000,000,007로 나눈 나머지를 반환.
```

#### 🧠 풀이 방법
```
1. 2차원 dp 배열 선언: dp[i][j] → 해당 위치까지 올 수 있는 경로 수
2. puddle은 먼저 -1로 표시
3. 시작점 (0,0)은 경로 1개로 초기화
4. 이후 각 칸은 위, 왼쪽 칸에서 오는 경로 수의 합을 저장
5. puddle일 경우 0으로 처리해 계산 제외
6. 결과는 dp[m-1][n-1] % 1,000,000,007
```

#### 💡 새로 알게 된 개념
키워드 | 설명
-- | --
puddle 선처리 | puddle을 먼저 -1로 표시하고 이후 계산에서 제외
dp[i][j] 누적 | 왼쪽과 위쪽의 경로 수를 더해 현재 칸 경로 수 계산
MOD 연산 | 결과가 커지지 않도록 1_000_000_007로 나머지 연산
continue 처리 | puddle은 계산을 아예 건너뛰도록 continue 사용

#### 🤔 막혔던 점
1. 시작점 dp[0][0]을 0으로 설정했더니 전체 경로가 0이 됨
→ dp[0][0] = 1로 초기화

2. puddle을 나중에 처리하면 초기값이 덮여 계산에 포함됨
→ puddle을 먼저 마킹해서 해결

---
### 3️⃣ 파괴되지 않은 건물
#### 📌 문제 설명
```
N x M 크기의 2차원 보드가 주어진다.
여러 번의 공격(또는 회복) 스킬이 적용될 때,  
최종적으로 내구도가 0보다 큰 칸의 개수를 구하라.

- 스킬은 [type, r1, c1, r2, c2, degree] 형태로 주어짐
- type == 1이면 공격 (내구도 감소), type == 2이면 회복 (내구도 증가)
```

#### 🧠 풀이 방법
```
1. 2차원 누적합 배열(sum) 선언
2. 스킬을 적용할 때, 시작 좌표에 degree 더하고 끝나는 좌표들에 -degree 처리
3. operate() 메서드를 통해 sum 배열을 상하, 좌우로 누적합 계산
4. 최종적으로 board + sum 값을 계산해 0보다 큰 칸 개수 세기
```

#### 💡 새로 알게 된 개념
키워드 | 설명
-- | --
2차원 누적합 (2D Prefix Sum) | 스킬 적용을 즉시 반영하지 않고 누적합으로 한 번에 처리
시작/끝 포인트 처리 | (r1,c1)에 +degree, (r1,c2+1), (r2+1,c1), (r2+1,c2+1)에 각각 -degree로 마킹
누적합 계산 순서 | 상→하 누적, 좌→우 누적 순으로 진행
보드 업데이트 | board[i][j] + sum[i][j]로 최종 내구도 계산

#### 🤔 막혔던 점
계속해서 정확성은 맞는데, 효율성을 틀렸다고 뜨게 됨 ㅠㅠ
```java
for(int i = 0; i<size; i++){
            int[] curSkill = skill[i];
            int type = curSkill[0], r1 = curSkill[1], c1 = curSkill[2],
                r2 = curSkill[3], c2 = curSkill[4], degree = curSkill[5];
            
            if(type == 1){ // 공격
                for(int r = r1; r <= r2; r++){
                    for(int c = c1; c <= c2; c++){
                        board[r][c] -= degree;
                    }
                }
            } else { // 회복
                for(int r = r1; r <= r2; r++){
                    for(int c = c1; c <= c2; c++){
                        board[r][c] += degree;
                    }
                }
            }
        }
```
<img width="527" alt="image" src="https://github.com/user-attachments/assets/f33b04fa-b5e6-4d70-9be8-f04bb50549cf" />
<img width="428" alt="image" src="https://github.com/user-attachments/assets/a6336d1b-e361-4421-a776-e881917041b4" />

누적합으로 바꿔서 풀었더니 해결!