### PR TITLE
7주차 이현진

### DIFF
--- a/src/week_7/백준_1753_최단경로_이현진.java
+++ b/src/week_7/백준_1753_최단경로_이현진.java
@@ -1,0 +1,56 @@
+package week_7;
+
+import java.util.*;
+
+public class 백준_1753_최단경로_이현진 {
+    private static ArrayList<ArrayList<int[]>> graph = new ArrayList<>();
+    private static int V, E, K;
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        V = sc.nextInt();
+        E = sc.nextInt();
+        K = sc.nextInt();
+
+        for (int i = 0; i < V + 1; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+        for (int i = 0; i < E; i++) {
+            int u, v, w;
+            u = sc.nextInt();
+            v = sc.nextInt();
+            w = sc.nextInt();
+            graph.get(u).add(new int[]{v, w});
+        }
+
+        int[] shortPath = dijkstra();
+        for (int i = 1; i <= V; i++) {
+            if (shortPath[i] == Integer.MAX_VALUE) System.out.println("INF");
+            else System.out.println(shortPath[i]);
+        }
+    }
+
+    public static int[] dijkstra() {
+        int[] dist = new int[V + 1]; // 도착지점, 가중치
+        Arrays.fill(dist, Integer.MAX_VALUE);
+        dist[K] = 0;
+
+        PriorityQueue<int[]> pq = new PriorityQueue<>(Comparator.comparingInt(o -> o[1])); // 가중치 기준 정렬
+        pq.offer(new int[]{K, 0});
+
+        while (!pq.isEmpty()) {
+            int[] current = pq.poll();
+            if (dist[current[0]] < current[1]) continue;
+
+            for (int[] next : graph.get(current[0])) {
+                // 저장된 다음 정점까지의 가중치 값 > 현재까지의 가중치 + 다음 정점까지의 가중치
+                if (dist[next[0]] > dist[current[0]] + next[1]) {
+                    dist[next[0]] = dist[current[0]] + next[1];
+                    pq.offer(new int[]{next[0], dist[next[0]]}); // 다음 정점으로 연결
+                }
+            }
+        }
+
+        return dist;
+    }
+}

--- a/src/week_7/프로그래머스_1_개인정보수집유효시간_이현진.java
+++ b/src/week_7/프로그래머스_1_개인정보수집유효시간_이현진.java
@@ -13,43 +13,32 @@ public class 프로그래머스_1_개인정보수집유효시간_이현진 {
     }
 
     public static Map<String, Integer> term = new HashMap<>();
-    public static int[] todayN = new int[3];
 
     public static int[] solution(String today, String[] terms, String[] privacies) {
         List<Integer> result = new ArrayList<>();
-        for (int i = 0; i < 3; i++) {
-            todayN[i] = Integer.parseInt(today.split("\\.")[i]);
-        }
-
         for (String i : terms) {
             term.put(i.split(" ")[0], Integer.parseInt(i.split(" ")[1]));
         }
 
+        int day = Integer.parseInt(today.split("\\.")[0]) * 12 * 28
+                + Integer.parseInt(today.split("\\.")[1]) * 28
+                + Integer.parseInt(today.split("\\.")[2]);
+
         for (int i = 0; i < privacies.length; i++) {
-            String type = privacies[i].split(" ")[1];
-            String date = privacies[i].split(" ")[0];
-            int y = Integer.parseInt(date.split("\\.")[0]);
-            int m = Integer.parseInt(date.split("\\.")[1]);
-            int d = Integer.parseInt(date.split("\\.")[2]);
-
-            if (!calculateDate(y, m, d, type)) result.add(i + 1);
+            if (calDate(privacies[i]) <= day) {
+                result.add(i + 1);
+            }
         }
-
         return result.stream().mapToInt(i -> i).toArray();
     }
 
-    private static boolean calculateDate(int y, int m, int d, String type) {
-        int plusM = term.get(type);
-        m += plusM;
+    private static int calDate(String privacy) {
+        String type = privacy.split(" ")[1];
+        String y = privacy.split(" ")[0].split("\\.")[0];
+        String m = privacy.split(" ")[0].split("\\.")[1];
+        String d = privacy.split(" ")[0].split("\\.")[2];
 
-        if (m > 12) {
-            y = y + (m - 1) / 12;
-            m = (m - 1) % 12 + 1;
-        }
-
-        if (todayN[0] < y) return true;
-        else if (todayN[0] == y && todayN[1] < m) return true;
-        else if (todayN[0] == y && todayN[1] == m && todayN[2] < d) return true;
-        return false;
+        int day = Integer.parseInt(y) * 12 * 28 + Integer.parseInt(m) * 28 + Integer.parseInt(d);
+        return (day + term.get(type) * 28);
     }
 }

--- a/src/week_7/프로그래머스_1_개인정보수집유효시간_이현진.java
+++ b/src/week_7/프로그래머스_1_개인정보수집유효시간_이현진.java
@@ -1,0 +1,55 @@
+package week_7;
+
+import java.util.*;
+
+public class 프로그래머스_1_개인정보수집유효시간_이현진 {
+    public static void main(String[] args) {
+        String today = "2022.11.28";
+        String[] terms = {"A 12"};
+        String[] privacies = {
+                "2021.11.28 A"
+        };
+        System.out.println(Arrays.toString(solution(today, terms, privacies)));
+    }
+
+    public static Map<String, Integer> term = new HashMap<>();
+    public static int[] todayN = new int[3];
+
+    public static int[] solution(String today, String[] terms, String[] privacies) {
+        List<Integer> result = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            todayN[i] = Integer.parseInt(today.split("\\.")[i]);
+        }
+
+        for (String i : terms) {
+            term.put(i.split(" ")[0], Integer.parseInt(i.split(" ")[1]));
+        }
+
+        for (int i = 0; i < privacies.length; i++) {
+            String type = privacies[i].split(" ")[1];
+            String date = privacies[i].split(" ")[0];
+            int y = Integer.parseInt(date.split("\\.")[0]);
+            int m = Integer.parseInt(date.split("\\.")[1]);
+            int d = Integer.parseInt(date.split("\\.")[2]);
+
+            if (!calculateDate(y, m, d, type)) result.add(i + 1);
+        }
+
+        return result.stream().mapToInt(i -> i).toArray();
+    }
+
+    private static boolean calculateDate(int y, int m, int d, String type) {
+        int plusM = term.get(type);
+        m += plusM;
+
+        if (m > 12) {
+            y = y + (m - 1) / 12;
+            m = (m - 1) % 12 + 1;
+        }
+
+        if (todayN[0] < y) return true;
+        else if (todayN[0] == y && todayN[1] < m) return true;
+        else if (todayN[0] == y && todayN[1] == m && todayN[2] < d) return true;
+        return false;
+    }
+}

--- a/src/week_7/프로그래머스_2_거리두기확인하기_이현진.java
+++ b/src/week_7/프로그래머스_2_거리두기확인하기_이현진.java
@@ -1,0 +1,81 @@
+package week_7;
+
+import java.util.Arrays;
+
+public class 프로그래머스_2_거리두기확인하기_이현진 {
+    public static void main(String[] args) {
+        String[][] places = {
+                {"POOOP", "OXXOX", "OPXPX", "OOXOX", "POXXP"},
+                {"POOPX", "OXPXP", "PXXXO", "OXXXO", "OOOPP"},
+                {"PXOPX", "OXOXP", "OXPOX", "OXXOP", "PXPOX"},
+                {"OOOXX", "XOOOX", "OOOXX", "OXOOX", "OOOOO"},
+                {"PXPXP", "XPXPX", "PXPXP", "XPXPX", "PXPXP"}
+        };
+        System.out.println(Arrays.toString(solution(places)));
+    }
+
+    public static int[] solution(String[][] places) {
+        int[] result = new int[5];
+
+        for (int i = 0; i < 5; i++) {
+            String[] place = places[i];
+            char[][] map = new char[5][5];
+
+            // 문자열 배열을 문자 배열로 변환
+            for (int r = 0; r < 5; r++) {
+                map[r] = place[r].toCharArray();
+            }
+
+            // 각 좌표 탐색
+            if (check(map)) result[i] = 1;
+            else result[i] = 0;
+        }
+
+        return result;
+    }
+
+    public static boolean check(char[][] map) {
+        for (int r = 0; r < 5; r++) {
+            for (int c = 0; c < 5; c++) {
+                if (map[r][c] != 'P') continue;
+
+                int[] dr = {-1, 1, 0, 0};
+                int[] dc = {0, 0, -1, 1};
+
+                int[] dr2 = {-2, 2, 0, 0};
+                int[] dc2 = {0, 0, -2, 2};
+
+                // 상하좌우 거리
+                for (int i = 0; i < 4; i++) { // 나를 기준으로 네 방향 탐색
+                    int nr = r + dr[i];
+                    int nc = c + dc[i];
+                    if (inRange(nr, nc) && map[nr][nc] == 'P') { // 사람이 있으면 탈락
+                        return false;
+                    }
+
+                    int nr2 = r + dr2[i];
+                    int nc2 = c + dc2[i];
+                    if(inRange(nr2, nc2) && map[nr2][nc2] == 'P' && map[nr][nc] != 'X'){ // 사람이 있으면 탈락
+                        return false;
+                    }
+                }
+
+                // 대각선
+                int[][] drc = {{-1,-1}, {-1,1}, {1,-1}, {1,1}};
+                for (int[] d : drc) {
+                    int nr = r + d[0];
+                    int nc = c + d[1];
+                    if(!inRange(nr, nc) || map[nr][nc] != 'P') continue;
+                    if(map[r][nc] != 'X' || map[nr][c] != 'X'){
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    private static boolean inRange(int r, int c) {
+        return r >= 0 && r < 5 && c >= 0 && c < 5;
+    }
+}

--- a/src/week_7/프로그래머스_3_합승택시요금_이현진.java
+++ b/src/week_7/프로그래머스_3_합승택시요금_이현진.java
@@ -1,0 +1,81 @@
+package week_7;
+
+import java.util.*;
+
+public class 프로그래머스_3_합승택시요금_이현진 {
+    public static void main(String[] args) {
+        int n = 6;
+        int s = 4;
+        int a = 6;
+        int b = 2;
+        int[][] fares = {
+                {4, 1, 10},
+                {3, 5, 24},
+                {5, 6, 2},
+                {3, 1, 41},
+                {5, 1, 24},
+                {4, 6, 50},
+                {2, 4, 66},
+                {2, 3, 22},
+                {1, 6, 25}
+        };
+
+        System.out.println(solution(n, s, a, b, fares));
+    }
+
+    static ArrayList<ArrayList<int[]>> graph = new ArrayList<>();
+
+    // 합승요금 보다 개별 요금이 싸면 합승 안해도 됨.
+    public static int solution(int n, int s, int a, int b, int[][] fares) {
+        for (int i = 0; i < n + 1; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+        // 노드 연결
+        for (int[] fare : fares) {
+            graph.get(fare[0]).add(new int[]{fare[1], fare[2]});
+            graph.get(fare[1]).add(new int[]{fare[0], fare[2]});
+        }
+
+        int[] distFromS = dijkstra(n, s);
+        int[] distFromA = dijkstra(n, a);
+        int[] distFromB = dijkstra(n, b);
+
+        int answer = Integer.MAX_VALUE;
+
+        for (int i = 1; i <= n; i++) {
+            if (distFromS[i] == Integer.MAX_VALUE ||
+                    distFromA[i] == Integer.MAX_VALUE ||
+                    distFromB[i] == Integer.MAX_VALUE) continue;
+
+            int cost = distFromS[i] + distFromA[i] + distFromB[i];
+            answer = Math.min(answer, cost);
+        }
+
+        return answer;
+    }
+
+    // 노드의 수, 시작 지점
+    private static int[] dijkstra(int n, int start) {
+        int[] dist = new int[n + 1]; // 도착지점, 비용
+        Arrays.fill(dist, Integer.MAX_VALUE); // 최대값으로 설정
+        dist[start] = 0;
+
+        PriorityQueue<int[]> pq = new PriorityQueue<>(Comparator.comparingInt(o -> o[1]));
+        pq.offer(new int[]{start, 0});
+
+        while (!pq.isEmpty()) {
+            int[] current = pq.poll();
+            if (dist[current[0]] < current[1]) continue;
+
+            for (int[] next : graph.get(current[0])) {
+                if (dist[next[0]] > dist[current[0]] + next[1]) {
+                    dist[next[0]] = dist[current[0]] + next[1];
+                    pq.offer(new int[]{next[0], dist[next[0]]});
+                }
+            }
+        }
+
+        return dist;
+    }
+}

--- a/src/week_7/프로그래머스_가장많이받은선물_이현진.java
+++ b/src/week_7/프로그래머스_가장많이받은선물_이현진.java
@@ -1,0 +1,73 @@
+package week_7;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class 프로그래머스_가장많이받은선물_이현진 {
+    public static void main(String[] args) {
+        String[] friends = {"a", "b", "c"};
+        String[] gifts = {
+                "a b", "a c", "b a", "b c"
+        };
+        System.out.println(solution(friends, gifts));
+    }
+
+    public static int solution(String[] friends, String[] gifts) {
+        int size = friends.length;
+        List<String> friend = new ArrayList<>(Arrays.asList(friends));
+
+        // 선물 지수 표
+        int[][] giftN = new int[size][size];
+
+        // 자기 자신은 0으로 초기화
+        for (int i = 0; i < size; i++) {
+            giftN[i][i] = 0;
+        }
+
+        for (String gift : gifts) {
+            String[] name = gift.split(" ");
+            // 준 사람 찾기
+            int a = friend.indexOf(name[0]);
+
+            // 받은 사람 찾기
+            int b = friend.indexOf(name[1]);
+
+            // 선물 줬다고 표시
+            giftN[a][b]++;
+        }
+
+        int[] giftCnt = new int[size];
+        for (int i = 0; i < size; i++) {
+            int sum = 0;
+            // 준 선물
+            for (int j = 0; j < size; j++) {
+                sum += giftN[i][j];
+            }
+
+            // 받은 선물
+            for (int j = 0; j < size; j++) {
+                sum -= giftN[j][i];
+            }
+
+            giftCnt[i] = sum;
+        }
+
+        int[] cnt = new int[size];
+        for (int i = 0; i < size; i++) {
+            for (int j = 0; j < size; j++) {
+                if (i == j) continue;
+
+                // 서로 주고 받은 선물지수 (선물의 수 - 받은 선물의 수)
+                if (giftN[i][j] == giftN[j][i]) { // 둘이 똑같이 주고 받았다면
+                    if (giftCnt[i] == giftCnt[j]) // 선물 지수까지 같다면
+                        continue;
+                    else if (giftCnt[i] > giftCnt[j]) cnt[i]++;
+                } else if (giftN[i][j] > giftN[j][i]) { // a가 더 많이 줬다면
+                    cnt[i]++;
+                }
+            }
+        }
+        return Arrays.stream(cnt).max().getAsInt();
+    }
+}

--- a/src/week_7/프로그래머스_가장많이받은선물_이현진.java
+++ b/src/week_7/프로그래머스_가장많이받은선물_이현진.java
@@ -1,8 +1,6 @@
 package week_7;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 public class 프로그래머스_가장많이받은선물_이현진 {
     public static void main(String[] args) {
@@ -18,11 +16,11 @@ public class 프로그래머스_가장많이받은선물_이현진 {
         List<String> friend = new ArrayList<>(Arrays.asList(friends));
 
         // 선물 지수 표
-        int[][] giftN = new int[size][size];
+        int[][] giftHistory = new int[size][size];
 
         // 자기 자신은 0으로 초기화
         for (int i = 0; i < size; i++) {
-            giftN[i][i] = 0;
+            giftHistory[i][i] = 0;
         }
 
         for (String gift : gifts) {
@@ -34,7 +32,7 @@ public class 프로그래머스_가장많이받은선물_이현진 {
             int b = friend.indexOf(name[1]);
 
             // 선물 줬다고 표시
-            giftN[a][b]++;
+            giftHistory[a][b]++;
         }
 
         int[] giftCnt = new int[size];
@@ -42,12 +40,12 @@ public class 프로그래머스_가장많이받은선물_이현진 {
             int sum = 0;
             // 준 선물
             for (int j = 0; j < size; j++) {
-                sum += giftN[i][j];
+                sum += giftHistory[i][j];
             }
 
             // 받은 선물
             for (int j = 0; j < size; j++) {
-                sum -= giftN[j][i];
+                sum -= giftHistory[j][i];
             }
 
             giftCnt[i] = sum;
@@ -59,11 +57,9 @@ public class 프로그래머스_가장많이받은선물_이현진 {
                 if (i == j) continue;
 
                 // 서로 주고 받은 선물지수 (선물의 수 - 받은 선물의 수)
-                if (giftN[i][j] == giftN[j][i]) { // 둘이 똑같이 주고 받았다면
-                    if (giftCnt[i] == giftCnt[j]) // 선물 지수까지 같다면
-                        continue;
-                    else if (giftCnt[i] > giftCnt[j]) cnt[i]++;
-                } else if (giftN[i][j] > giftN[j][i]) { // a가 더 많이 줬다면
+                if (giftHistory[i][j] == giftHistory[j][i]) { // 둘이 똑같이 주고 받았다면
+                    if (giftCnt[i] > giftCnt[j]) cnt[i]++;
+                } else if (giftHistory[i][j] > giftHistory[j][i]) { // a가 더 많이 줬다면
                     cnt[i]++;
                 }
             }

--- a/src/week_7/프로그래머스_힙_이중우선순위큐.java
+++ b/src/week_7/프로그래머스_힙_이중우선순위큐.java
@@ -1,0 +1,43 @@
+package week_7;
+
+import java.util.Collections;
+import java.util.LinkedList;
+
+public class 프로그래머스_힙_이중우선순위큐 {
+    public static void main(String[] args) {
+        String[] operations = {
+                "I -45",
+                "I 653",
+                "D 1",
+                "I -642",
+                "I 45",
+                "I 97",
+                "D 1",
+                "D -1",
+                "I 333"
+        };
+        System.out.println(solution(operations));
+    }
+
+    public static int[] solution(String[] operations) {
+        LinkedList<Integer> list = new LinkedList<>();
+
+        for (String operation : operations) {
+            String o = operation.split(" ")[0];
+            int v = Integer.parseInt(operation.split(" ")[1]);
+
+            if (o.equals("I")) {
+                list.add(v);
+                Collections.sort(list);
+            } else if (o.equals("D") && v == -1 && !list.isEmpty()) {
+                list.removeFirst();
+            } else if (o.equals("D") && v == 1 && !list.isEmpty()) {
+                list.removeLast();
+            }
+        }
+
+        if (list.isEmpty()) return new int[]{0, 0};
+        return new int[]{list.getLast(), list.getFirst()};
+    }
+}
+


### PR DESCRIPTION
## ✨ Week 7

### 1️⃣ 개인정보 수집 유효기간
#### 📌 문제 설명
```
오늘 날짜(today)와 개인정보 수집 일자(privacies),  
약관 유효기간(terms)이 주어질 때,  
파기해야 할 개인정보의 번호를 구하라.
```

#### 🧠 풀이 방법
```
1. terms 배열을 Map에 저장 (약관 종류 → 유효 개월 수)
2. 날짜를 모두 일(day) 단위로 변환하여 비교
   - 1개월 = 28일, 1년 = 12개월로 계산
3. 각 개인정보 수집 일자에 약관 기간을 더한 값과 today를 비교하여 파기 여부 판단
4. 파기 대상인 경우, 번호(i + 1)를 결과 리스트에 저장
```

#### 💡 새로 알게 된 개념
키워드 | 설명
-- | --
날짜 일수 변환 | 연1228 + 월*28 + 일로 모든 날짜를 일 단위로 통일
Map 활용 | 약관 종류별 유효기간을 key-value로 관리
split 정리 | 한 문자열 안의 날짜와 약관 코드를 분리

#### 🤔 막혔던 점
초기에는 날짜 비교 시 월 단위로 계산하려 했으나,
일수로 변환하면 훨씬 간단하게 처리할 수 있다는 것을 깨달음
→ 기준을 '일'로 통일하니 코드가 깔끔해졌음

---
### 2️⃣ 거리두기 확인하기
#### 📌 문제 설명
```
5x5 대기실 배열이 주어질 때,  
모든 응시자가 거리두기를 지키고 있는지 확인하라.

- 맨해튼 거리 2 이내에 다른 사람이 있으면 안 됨
- 단, 파티션(X)이 있다면 예외
```

#### 🧠 풀이 방법
```
1. 각 대기실을 2차원 char 배열로 변환
2. 응시자(P) 위치를 기준으로 상하좌우, 대각선, 2칸 떨어진 곳을 탐색
3. 조건 위반 시 false 반환
4. 모든 조건을 만족하면 1, 아니면 0으로 결과 배열에 저장
```

#### 💡 새로 알게 된 개념
키워드 | 설명
-- | --
2칸 거리 탐색 | 방향 배열을 이용해 거리 2까지 탐색
파티션 조건 체크 | 중간 칸이 X가 아닐 때만 거리 위반으로 간주
대각선 조건 | 주변 두 칸이 모두 파티션일 경우만 허용

#### 🤔 막혔던 점
처음에는 단순 상하좌우만 체크했는데,
문제를 잘 읽고 나니 거리 2와 대각선 조건까지 고려해야 해서 추가 구현이 필요했음
→ 방향 배열을 두 개 두어 거리 1, 2, 대각선을 분리해서 처리함

---
### 3️⃣ 합승 택시 요금
#### 📌 문제 설명
```
택시를 타고 출발지 s에서 각자 목적지 a, b까지 가려 한다.  
합승해서 이동할 수 있다면, 요금이 절약됨.

- n: 정점 수
- fares: 노드 간 요금
- s → a, s → b 각각의 비용 + 합승 경로를 고려한 최소 요금을 구하라.
```

#### 🧠 풀이 방법
```
1. 노드마다 연결 정보를 인접 리스트(graph)로 저장
2. s, a, b에서 각각 Dijkstra 알고리즘을 수행하여 거리 배열 획득
3. 모든 노드를 경유지 후보로 두고:
   distFromS[i] + distFromA[i] + distFromB[i]의 합 최소값을 탐색
4. 해당 최소값이 정답
```

#### 💡 새로 알게 된 개념
키워드 | 설명
-- | --
다익스트라 (Dijkstra) | 최소 경로 비용 탐색을 위한 우선순위 큐 기반 알고리즘
세 번의 다익스트라 | 출발지(s)와 도착지들(a, b) 기준의 거리 배열 필요
경유지 탐색 | i번 노드를 공유 택시 경유지로 두고 전체 최소 비용 계산

#### 🤔 막혔던 점
초기에는 s → a → b 같은 단순 경로만 고려했는데,
모든 노드를 경유지로 놓고 비용을 계산해야 정답을 도출할 수 있음을 깨달음
